### PR TITLE
fixed untracked files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 ### local ###
 application-local.yml
+application-test.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN gradle dependencies --no-daemon
 COPY . .
 
 # Gradle 빌드를 실행하여 JAR 파일 생성
-RUN gradle clean build -x test --no-daemon
+#RUN gradle clean build -x test --no-daemon (테스트 실행 제외 버전)
+RUN gradle clean build --no-daemon
 
 # 런타임 이미지로 OpenJDK 17-jre-slim 지정
 FROM openjdk:17-slim
@@ -22,8 +23,8 @@ FROM openjdk:17-slim
 WORKDIR /app
 
 # 빌드 이미지에서 생성된 JAR 파일을 런타임 이미지로 복사
-COPY --from=build /app/build/libs/*.jar /app/conolja-0.0.1-SNAPSHOT.jar
+COPY --from=build /app/build/libs/*.jar /app/conolja.jar
 
 EXPOSE 8080 
 ENTRYPOINT ["java"] 
-CMD ["-jar", "conolja-0.0.1-SNAPSHOT.jar"]
+CMD ["-jar", "conolja.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'site.javaghost'
-version = '0.0.1-SNAPSHOT'
+//version = '0.1.0'
 
 java {
     toolchain {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -3,7 +3,19 @@ spring:
     activate:
       on-profile: local # 어플리케이션의 프로파일 설정
 
+  jpa:
+    hibernate:
+      ddl-auto: update  # 테이블이 없을 경우 생성, 테이블이 있을 경우 변경사항을 반영
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        show_sql: false
+        format_sql: false
+        default_batch_fetch_size: 100
+    open-in-view: false
+
   datasource:
+    driver-class-name: org.postgresql.Driver
     url: jdbc:postgresql://localhost:5432/conolja-local?currentSchema=conolja
     username: mwjeong
     password: Wsxqaz1425!

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,9 +6,6 @@ spring:
   application:
     name: conolja-api  # 어플리케이션 이름 설정
 
-  datasource:
-    driver-class-name: org.postgresql.Driver
-
   jpa:
     hibernate:
       ddl-auto: update  # 테이블이 없을 경우 생성, 테이블이 있을 경우 변경사항을 반영

--- a/src/test/java/site/javaghost/conolja/ConoljaApplicationTests.java
+++ b/src/test/java/site/javaghost/conolja/ConoljaApplicationTests.java
@@ -2,11 +2,16 @@ package site.javaghost.conolja;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles("local")
+@ActiveProfiles("test")
 class ConoljaApplicationTests {
+
+	@MockBean
+	private SecurityFilterChain securityFilterChain;
 
 	@Test
 	void contextLoads() {

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,26 +1,19 @@
 spring:
   config:
     activate:
-      on-profile: dev
-
-  datasource:
-    driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://postgres:5432/conolja-dev
-    username: conolja
-    password: conolja123!@#
+      on-profile: test # 어플리케이션의 프로파일 설정
 
   jpa:
     hibernate:
       ddl-auto: update  # 테이블이 없을 경우 생성, 테이블이 있을 경우 변경사항을 반영
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
         show_sql: false
         format_sql: false
         default_batch_fetch_size: 100
     open-in-view: false
 
-
 springdoc:
   servers:
-    - "https://api.conolja.site${server.servlet.context-path}"
+    - "http://localhost:8080${server.servlet.context-path}"
+


### PR DESCRIPTION
[테스트 코드 실행시 SecurityFilterChain 빈이 중복 등록 에러가 발생]
- @SpringBootTest 어노테이션의 경우 빈을 여러번 실행하기 때문에 SecurityFilterChain 빈을 여러번 등록하면서 에러 발생
- SecurityFilterChain 빈을 @MockBean 으로 대체

[테스트 코드용 환경파일 추가 application-test.yml]
- gitignore 파일에 추가
- 개인별로 application-test.yml 관리 필요